### PR TITLE
Relax bounds on base, compatible with template-haskell 2.16

### DIFF
--- a/lens-family-th.cabal
+++ b/lens-family-th.cabal
@@ -24,8 +24,8 @@ library
   exposed-modules:   Lens.Family.TH
                    , Lens.Family2.TH
                    , Lens.Family.THCore
-  build-depends:     base >= 4.9 && < 4.14
-                   , template-haskell >= 2.11 && < 2.16
+  build-depends:     base >= 4.9 && < 4.15
+                   , template-haskell >= 2.11 && < 2.17
 
 test-suite lens-family-th-test
   type:              exitcode-stdio-1.0

--- a/src/Lens/Family/THCore.hs
+++ b/src/Lens/Family/THCore.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE CPP             #-}
 
 -- | The shared functionality behind Lens.Family.TH and Lens.Family2.TH.
 module Lens.Family.THCore (
@@ -208,7 +209,13 @@ argPatFrom xs = TupP (map VarP xs)
 argTupFrom :: [Name] -> Exp
 argTupFrom [] = unitExp
 argTupFrom [x] = VarE x
-argTupFrom xs = TupE (map VarE xs)
+argTupFrom xs = TupE $
+  map (
+#if MIN_VERSION_template_haskell(2,16,0)
+    Just .
+#endif
+    VarE
+  ) xs
 
 argVarsFrom :: [Name] -> [Exp]
 argVarsFrom = map VarE


### PR DESCRIPTION
Ghc 8.10 compatibility fix. Not tested with older `template-haskell` versions yet.